### PR TITLE
Fix hard fault which is triggered on a disconnect

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -43,7 +43,7 @@
 #define DEBUG_SENSOR_POLLING 0
 
 // Erases the block device during filesystem initialization
-#define ERASE_BLOCK_DEVICE 0
+#define ERASE_BLOCK_DEVICE 1
 
 #define POLL_INTERVAL_MS 5000 // Sensor polling interval in milliseconds
 
@@ -339,7 +339,7 @@ bool create_filesystem()
 
 	/** Slice it so we only use part of it for the filesystem */
 	static SlicingBlockDevice sbd(BlockDevice::get_default_instance(),
-			0, (64*1024));
+			0, (128*1024));
 	fsbd = &sbd;
     BlockDevice& bd = *fsbd;
 

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#679d24833acf0a0b5b0d528576bb37c70863bc4e
+https://github.com/ARMmbed/mbed-os/#e4b81f67f939a0c0b11c147ce74aa367271e1279

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#0d26be4af22725cf34eeefa5c8b3e4219eb70543
+https://github.com/ARMmbed/mbed-os/#679d24833acf0a0b5b0d528576bb37c70863bc4e


### PR DESCRIPTION
It looks like Mbed OS 5.14.2 introduced a bug where the target hard faults upon a BLE disconnect. Quick workaround is to revert to Mbed OS 5.14.1.

See #2.