### PR TITLE
Update to latest version of 'ep-oc-mcu'

### DIFF
--- a/ep-oc-mcu.lib
+++ b/ep-oc-mcu.lib
@@ -1,1 +1,1 @@
-https://github.com/EmbeddedPlanet/ep-oc-mcu/#8f551d00d3bdec2653979b6fd042a01fa7c98132
+https://github.com/EmbeddedPlanet/ep-oc-mcu/#b8eac1fd7848e2982c0d0cb6ab395336572facc5


### PR DESCRIPTION
Update to latest version of 'ep-oc-mcu' that has support for Mbed-OS 5.x and ARMC6